### PR TITLE
Add logs & Migrate from @react-native-community/async-storage to @react-native-async-storage/async-storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ import { NavigationContainer as ReactNavigationContainer } from "@react-navigati
 import { enableLiveReloadOnScreen } from "@bam.tech/react-navigation-live-reload-on-screen";
 
 const ENABLE_LIVE_RELOAD = __DEV__;
-const NavigationContainer = enableLiveReloadOnScreen(ENABLE_LIVE_RELOAD)(
+const ENABLE_LIVE_RELOAD_LOGS = true;
+const NavigationContainer = enableLiveReloadOnScreen(ENABLE_LIVE_RELOAD, ENABLE_LIVE_RELOAD_LOGS)(
   ReactNavigationContainer
 );
 

--- a/index.tsx
+++ b/index.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Linking, Platform } from "react-native";
-import AsyncStorage from "@react-native-community/async-storage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import {
   NavigationContainer,
   NavigationState,

--- a/index.tsx
+++ b/index.tsx
@@ -9,6 +9,7 @@ import {
   Theme,
   LinkingOptions,
   DocumentTitleOptions,
+  InitialState,
 } from "@react-navigation/native";
 export const PERSISTENCE_KEY = "NAVIGATION_STATE";
 
@@ -73,7 +74,7 @@ declare type NavigationContainerType<Params extends {}> = (
 ) => React.ReactElement;
 
 export const enableLiveReloadOnScreen =
-  (enable: boolean) =>
+  (enable: boolean, logs: boolean = true) =>
   <Params extends {} = {}>(
     NavigationContainerComponent: NavigationContainerType<Params>
   ) => {
@@ -84,6 +85,18 @@ export const enableLiveReloadOnScreen =
       ) => {
         const { waitForLiveReload, props: liveReloadProps } =
           useLiveReloadOnScreen();
+
+        React.useEffect(() => {
+          if (logs && !waitForLiveReload) {
+            const activeRouteName = getActiveRouteName(liveReloadProps.initialState);
+            if (activeRouteName) {
+              console.log("[Live Reload on Screen] App reloaded on", activeRouteName);
+            } else {
+              console.log("[Live Reload on Screen] No reload, either because the app was opened with a deep link or because this is the first time the app has been launched");
+            }
+          }
+        }, [waitForLiveReload]);
+
         if (waitForLiveReload) return null;
 
         const onStateChange = (state: NavigationState | undefined) => {
@@ -113,3 +126,19 @@ export const enableLiveReloadOnScreen =
 
 export const clearNavigationState = (): Promise<void> =>
   AsyncStorage.removeItem(PERSISTENCE_KEY);
+
+const getActiveRouteName = (navigationState?: InitialState): string | null => {
+  if (!navigationState) return null;
+
+  const { index, routes } = navigationState;
+  if (index === undefined || index >= routes.length) return null;
+
+  const activeRoute = routes[index];
+
+  // If the active route has a nested state, recurse
+  if (activeRoute.state) {
+    return getActiveRouteName(activeRoute.state);
+  }
+
+  return activeRoute.name;
+};

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "@react-native-community/async-storage": "*",
+    "@react-native-async-storage/async-storage": "*",
     "@react-navigation/native": "*"
   },
   "author": "Almouro",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bam.tech/react-navigation-live-reload-on-screen",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Make live reload to stay on current screen with react-navigation",
   "main": "index.tsx",
   "scripts": {},
@@ -19,6 +19,7 @@
     "@react-navigation/native": "*"
   },
   "author": "Almouro",
+  "contributors": ["vicprz"],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/bamlab/react-navigation-live-reload-on-screen/issues"


### PR DESCRIPTION
### Add Logs

Added an optional parameter to `enableLiveReloadOnScreen` to display logs in the console when the app is reloaded:

- `[Live Reload on Screen] App reloaded on + activeRouteName`
- `[Live Reload on Screen] No reload, either because the app was opened with a deep link or because this is the first time the app has been launched`

This is useful for debugging and is non-intrusive.

### Migrate from `@react-native-community/async-storage` to `@react-native-async-storage/async-storage`

- Async Storage has been migrated to `@react-native-async-storage/async-storage`.
- Closes issue #1.